### PR TITLE
Model integration testing

### DIFF
--- a/api/src/models.py
+++ b/api/src/models.py
@@ -16,7 +16,7 @@ from validation import ModelSchema, DojoSchema
 
 from src.settings import settings
 from src.dojo import search_and_scroll, copy_configs, copy_outputfiles, copy_directive, copy_accessory_files
-from src.utils import plugin_action
+from src.utils import plugin_action, run_model_with_defaults
 
 
 router = APIRouter()
@@ -295,4 +295,15 @@ def publish_model(model_id: str, publish_data: ModelSchema.PublishSchema):
     return Response(
         status_code=status.HTTP_200_OK,
         content="Model published",
+    )
+
+@router.post("/models/{model_id}/test")
+def test_model(model_id: str):
+    """
+    This endpoint tests a model's functionality within Dojo.
+    """
+    run_id = run_model_with_defaults(model_id)
+    return Response(
+        status_code=status.HTTP_200_OK,
+        content=f"Model test run submitted with run id {run_id}",
     )

--- a/api/src/runs.py
+++ b/api/src/runs.py
@@ -337,3 +337,14 @@ def update_run(payload: RunSchema.ModelRunSchema):
         headers={"location": f"/api/runs/{run_id}"},
         content=f"Updated run with id = {run_id}",
     )
+
+
+@router.get("/runs/{run_id}/test")
+def test_run_status(run_id: str) -> RunSchema.RunStatusSchema:
+    run = get_run(run_id)
+    status = run.get("attributes",{}).get("status",None)
+    if status:
+        es.index(index="tests", body=body, id=model_id)
+        return status
+    else:
+        return "running"

--- a/api/src/utils.py
+++ b/api/src/utils.py
@@ -1,5 +1,11 @@
+from dojo.api.src.models import current_milli_time
 from validation import ModelSchema
 from fastapi.logger import logger
+import time
+from elasticsearch import Elasticsearch
+
+from src.settings import settings
+es = Elasticsearch([settings.ELASTICSEARCH_URL], port=settings.ELASTICSEARCH_PORT)
 
 
 def try_parse_int(s: str, default: int = 0) -> int:
@@ -36,6 +42,42 @@ def delete_matching_records_from_model(model_id, record_key, record_test):
     modify_model(model_id, ModelSchema.ModelMetadataPatchSchema(**update))
 
     return record_count
+
+
+def run_model_with_defaults(model_id):
+    """
+    This function takes in a model and submits a default run to test that model's functionality
+    """
+
+    from src.models import get_model 
+    from src.runs import create_run, current_milli_time
+    from validation import RunSchema
+
+    model = get_model(model_id)
+
+    params = []
+    for param in model.get("parameters",[]):
+        param_obj = {}
+        param_obj['name'] = param['name']
+        param_obj['value'] = param['default']
+        params.append(param_obj)
+    
+    run_id = f"{model['name']}-{current_milli_time()}"
+
+    run = RunSchema(id=run_id,
+                    model_id=model_id,
+                    model_name=model["name"],
+                    parameters=params,
+                    is_default_run=True,
+                    created_at = current_milli_time())
+
+    create_run(run)
+
+    # Store model ID to `tests` index with `status` set to `running`
+    body = {"status": "running", "created_at": run.created_at, "run_id": run.id}
+    es.index(index="tests", body=body, id=model_id)
+
+    return run_id
 
 
 def plugin_action(action_name, **kwargs):

--- a/api/validation/RunSchema.py
+++ b/api/validation/RunSchema.py
@@ -96,3 +96,8 @@ class RunLogsSchema(BaseModel):
         description="tasks",
         title="tasks",
     )
+
+class RunStatusSchema(Enum):
+    success = "success"
+    running = "running"
+    failed = "failed"


### PR DESCRIPTION
@mattprintz this is *not* ready for a PR since I have not tested this at all...I mostly just wanted to use this as a means to get your thoughts on this approach.

My simple idea here (how can we make this more automated?!) is this:

1. Add a function to `models.py` to test a model by creating a default run.
2. Add function to `utils.py` to do the default run for the model and store that info to a `tests` ES index
3. Add function to `runs.py` which checks the status of test runs and updates `tests` index if the status is now `success` or `failure` (instead of running)

We'd basically run 2 crons:

1. Something that periodically (weekly?) submits to `/models/test` for each model `model_id` that is `published`. Write the `run_ids` to a log file `test_runs.log`
2. Something that periodically (daily?) reads `test_runs.log` and submits to `/runs/test` for each `run_id`

We'd then update the model overview page in the UI to add a column for the test run status.

> *NOTE* to reiterate I've not tested _any_ of this code, just wanted your take on the approach. Ideally we'd be doing this without crons and endpoint polling, but I'm fine with something quick and dirty if you don't mind it.